### PR TITLE
Definindo caminho de assets como relativo

### DIFF
--- a/_layouts/layout.html
+++ b/_layouts/layout.html
@@ -6,9 +6,9 @@
     <meta name="author" content="">
     <meta name='yandex-verification' content='503886b4dce5cbba' />
 
-    <link href="/assets/bootstrap/css/bootstrap.css" rel="stylesheet">
-    <link href="/assets/bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="/assets/css/pygments.css" rel="stylesheet">
+    <link href="assets/bootstrap/css/bootstrap.css" rel="stylesheet">
+    <link href="assets/bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="assets/css/pygments.css" rel="stylesheet">
     <title>{{ page.title }}</title>
 </head>
 <body onload="prettyPrint()">


### PR DESCRIPTION
Com esta alteração os assets presentes no repositório funcionarão tanto no github.io quanto em um outro domínio existente.
